### PR TITLE
feat(epic-135): UI Congruence — Shared PageHeader, Pinned Projects & Low Stock Warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10888,6 +10888,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -20159,6 +20160,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
           "optional": true
         }
       }

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import Home from '../page';
+
+jest.mock('next/link', () => {
+  const MockLink = ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  );
+  MockLink.displayName = 'MockLink';
+  return MockLink;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type LotStub = {
+  partId: string;
+  quantity: number | null;
+  part: { id: string; name: string };
+};
+
+function makeLot(partId: string, partName: string, quantity: number | null = 3): LotStub {
+  return {
+    partId,
+    quantity,
+    part: { id: partId, name: partName },
+  };
+}
+
+function mockFetch(lowLots: LotStub[] = [], outLots: LotStub[] = []) {
+  global.fetch = jest.fn().mockImplementation((url: string) => {
+    // The unified Home component also fetches active projects — return empty array for that endpoint
+    if ((url as string).includes('/api/projects')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      } as Response);
+    }
+    const lots = url.includes('status=low') ? lowLots : outLots;
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ data: lots }),
+    } as Response);
+  });
+}
+
+function mockFetchError() {
+  global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+}
+
+function mockFetchNotOk() {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    json: () => Promise.resolve({ data: [] }),
+  } as unknown as Response);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Home page — low stock warnings', () => {
+  it('does not render Low Stock Warnings section when no low/out lots exist', async () => {
+    mockFetch([], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    expect(screen.queryByText(/low stock warnings/i)).not.toBeInTheDocument();
+  });
+
+  it('renders Low Stock Warnings heading when low lots are returned', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k')], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/low stock warnings/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders Low Stock Warnings heading when out lots are returned', async () => {
+    mockFetch([], [makeLot('part-2', 'LED Red')]);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/low stock warnings/i)).toBeInTheDocument();
+    });
+  });
+
+  it('displays the part name in each alert', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k')], [makeLot('part-2', 'LED Red')]);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Resistor 10k')).toBeInTheDocument();
+      expect(screen.getByText('LED Red')).toBeInTheDocument();
+    });
+  });
+
+  it('displays the total quantity for each part', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 4)], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Qty: 4')).toBeInTheDocument();
+    });
+  });
+
+  it('sums quantities across multiple lots for the same part', async () => {
+    const lot1 = makeLot('part-1', 'Resistor 10k', 3);
+    const lot2 = makeLot('part-1', 'Resistor 10k', 7);
+    mockFetch([lot1], [lot2]);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Qty: 10')).toBeInTheDocument();
+    });
+  });
+
+  it('treats null quantity as 0 when summing', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', null)], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Qty: 0')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a "View Part" link pointing to /parts/[id] for each part', async () => {
+    mockFetch([makeLot('part-abc', 'Capacitor')], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /view part/i });
+      expect(link).toHaveAttribute('href', '/parts/part-abc');
+    });
+  });
+
+  it('renders one alert per unique part, not per lot', async () => {
+    const lot1 = makeLot('part-1', 'Resistor 10k', 2);
+    const lot2 = makeLot('part-1', 'Resistor 10k', 3);
+    const lot3 = makeLot('part-2', 'LED Red', 1);
+    mockFetch([lot1, lot2], [lot3]);
+    render(<Home />);
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts).toHaveLength(2);
+    });
+  });
+
+  it('silently ignores fetch errors — no error message shown', async () => {
+    mockFetchError();
+    render(<Home />);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+
+    expect(screen.queryByText(/low stock warnings/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it('silently ignores non-ok fetch responses — section stays hidden', async () => {
+    mockFetchNotOk();
+    render(<Home />);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+
+    expect(screen.queryByText(/low stock warnings/i)).not.toBeInTheDocument();
+  });
+
+  it('fetches both low and out status endpoints', async () => {
+    mockFetch([], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    const calls = (global.fetch as jest.Mock).mock.calls.map(([url]: [string]) => url);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('status=low'),
+        expect.stringContaining('status=out'),
+      ]),
+    );
+  });
+});
+
+describe('Home page — threshold management', () => {
+  it('shows default threshold of 5 when localStorage is empty', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      const input = screen.getByLabelText(/stock threshold for resistor 10k/i);
+      expect((input as HTMLInputElement).value).toBe('5');
+    });
+  });
+
+  it('loads a persisted threshold from localStorage', async () => {
+    localStorage.setItem('stock-thresholds', JSON.stringify({ 'part-1': 10 }));
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => {
+      const input = screen.getByLabelText(/stock threshold for resistor 10k/i);
+      expect((input as HTMLInputElement).value).toBe('10');
+    });
+  });
+
+  it('updates threshold display as user types', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => screen.getByLabelText(/stock threshold for resistor 10k/i));
+
+    const input = screen.getByLabelText(/stock threshold for resistor 10k/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '15' } });
+    expect(input.value).toBe('15');
+  });
+
+  it('saves valid threshold to localStorage on blur', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => screen.getByLabelText(/stock threshold for resistor 10k/i));
+
+    const input = screen.getByLabelText(/stock threshold for resistor 10k/i);
+    fireEvent.change(input, { target: { value: '20' } });
+    fireEvent.blur(input);
+
+    const stored = JSON.parse(localStorage.getItem('stock-thresholds') ?? '{}');
+    expect(stored['part-1']).toBe(20);
+  });
+
+  it('falls back to DEFAULT_THRESHOLD (5) when blur value is not a valid number', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => screen.getByLabelText(/stock threshold for resistor 10k/i));
+
+    const input = screen.getByLabelText(/stock threshold for resistor 10k/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'abc' } });
+    fireEvent.blur(input);
+
+    expect(input.value).toBe('5');
+    const stored = JSON.parse(localStorage.getItem('stock-thresholds') ?? '{}');
+    expect(stored['part-1']).toBe(5);
+  });
+
+  it('falls back to DEFAULT_THRESHOLD when blur value is negative', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => screen.getByLabelText(/stock threshold for resistor 10k/i));
+
+    const input = screen.getByLabelText(/stock threshold for resistor 10k/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '-3' } });
+    fireEvent.blur(input);
+
+    expect(input.value).toBe('5');
+  });
+
+  it('accepts 0 as a valid threshold', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => screen.getByLabelText(/stock threshold for resistor 10k/i));
+
+    const input = screen.getByLabelText(/stock threshold for resistor 10k/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.blur(input);
+
+    expect(input.value).toBe('0');
+    const stored = JSON.parse(localStorage.getItem('stock-thresholds') ?? '{}');
+    expect(stored['part-1']).toBe(0);
+  });
+
+  it('does not save to localStorage if input was not changed before blur', async () => {
+    mockFetch([makeLot('part-1', 'Resistor 10k', 2)], []);
+    render(<Home />);
+
+    await waitFor(() => screen.getByLabelText(/stock threshold for resistor 10k/i));
+
+    const input = screen.getByLabelText(/stock threshold for resistor 10k/i);
+    fireEvent.blur(input);
+
+    // No change event fired, so thresholdInputs['part-1'] is undefined → no save
+    expect(localStorage.getItem('stock-thresholds')).toBeNull();
+  });
+});
+
+describe('Home page — static content', () => {
+  it('renders the page heading', async () => {
+    mockFetch([], []);
+    render(<Home />);
+
+    expect(screen.getByRole('heading', { name: /welcome to hobby inventory/i })).toBeInTheDocument();
+  });
+
+  it('renders navigation links for core sections', async () => {
+    mockFetch([], []);
+    render(<Home />);
+
+    expect(screen.getByRole('link', { name: /add to inventory/i })).toHaveAttribute('href', '/intake');
+    expect(screen.getByRole('link', { name: /browse parts/i })).toHaveAttribute('href', '/parts');
+    // The nav links contain full text including descriptions; query by heading content within link
+    expect(document.querySelector('a[href="/lots"]')).toBeInTheDocument();
+    expect(document.querySelector('a[href="/locations"]')).toBeInTheDocument();
+    expect(document.querySelector('a[href="/projects"]')).toBeInTheDocument();
+  });
+});

--- a/src/app/import/page.tsx
+++ b/src/app/import/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ImportForm } from '@/features/import/components/ImportForm';
+import { PageHeader } from '@/components/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Import CSV — Hobby Inventory',
@@ -10,15 +11,13 @@ export default function ImportPage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-4xl px-4 py-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-foreground">CSV Import</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Bulk-import locations, parts, and lots from CSV files. Always run a dry-run first.
-          </p>
-          <div className="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-800">
-            <strong>Recommended order:</strong> Import <em>locations</em> first, then <em>parts</em>, then <em>lots</em>.
-            Lots must reference existing parts and locations by name/path.
-          </div>
+        <PageHeader
+          title="CSV Import"
+          description="Bulk-import locations, parts, and lots from CSV files. Always run a dry-run first."
+        />
+        <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-800">
+          <strong>Recommended order:</strong> Import <em>locations</em> first, then <em>parts</em>, then <em>lots</em>.
+          Lots must reference existing parts and locations by name/path.
         </div>
 
         <div className="rounded-xl border border-border bg-card p-6 shadow-sm">

--- a/src/app/intake/page.tsx
+++ b/src/app/intake/page.tsx
@@ -1,4 +1,5 @@
 import { IntakeForm } from '@/features/intake/components/IntakeForm';
+import { PageHeader } from '@/components/PageHeader';
 
 export const metadata = {
   title: 'Add to Inventory · Hobby Inventory',
@@ -8,12 +9,10 @@ export default function IntakePage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-xl px-4 py-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-foreground">Quick Add</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Add parts and lots to your inventory in seconds.
-          </p>
-        </div>
+        <PageHeader
+          title="Quick Add"
+          description="Add parts and lots to your inventory in seconds."
+        />
         <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
           <IntakeForm />
         </div>

--- a/src/app/locations/[id]/page.tsx
+++ b/src/app/locations/[id]/page.tsx
@@ -1,6 +1,7 @@
 import prisma from '@/lib/db';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import { PageHeader } from '@/components/PageHeader';
 
 export const dynamic = 'force-dynamic';
 
@@ -64,19 +65,18 @@ export default async function LocationDetailPage({ params }: Params) {
         <span className="text-gray-900 font-medium">{location.name}</span>
       </nav>
 
-      {/* Header */}
-      <div className="flex items-start justify-between mb-6 gap-4">
-        <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-gray-900">{location.name}</h1>
-          <p className="text-gray-400 text-xs mt-1 font-mono truncate">{location.path}</p>
-        </div>
-        <Link
-          href="/locations"
-          className="px-3 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 flex-shrink-0"
-        >
-          ← Back
-        </Link>
-      </div>
+      <PageHeader
+        title={location.name}
+        description={<span className="font-mono text-xs text-muted-foreground">{location.path}</span>}
+        actions={
+          <Link
+            href="/locations"
+            className="px-3 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted flex-shrink-0"
+          >
+            ← Back
+          </Link>
+        }
+      />
 
       {/* Notes */}
       {location.notes && (

--- a/src/app/locations/__tests__/page.test.tsx
+++ b/src/app/locations/__tests__/page.test.tsx
@@ -65,12 +65,21 @@ jest.mock('@/components/ui/select', () => {
   };
 });
 
-const mockLocations: { id: string; name: string; path: string; parentId: string | null; notes: string | null }[] = [
+interface LocationFixture {
+  id: string;
+  name: string;
+  path: string;
+  parentId: string | null;
+  notes: string | null;
+  children?: { id: string; name: string; path: string }[];
+}
+
+const mockLocations: LocationFixture[] = [
   { id: 'loc-1', name: 'Shelf A', path: 'Shelf A', parentId: null, notes: null },
   { id: 'loc-2', name: 'Bin B', path: 'Shelf A > Bin B', parentId: 'loc-1', notes: 'Top shelf' },
 ];
 
-function mockFetchSuccess(locations = mockLocations) {
+function mockFetchSuccess(locations: LocationFixture[] = mockLocations) {
   global.fetch = jest.fn().mockResolvedValueOnce({
     json: async () => ({ data: locations }),
   } as Response);

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -29,6 +29,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { PageHeader } from '@/components/PageHeader';
 
 interface LocationData {
   id: string;
@@ -196,22 +197,25 @@ export default function LocationsPage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-7xl px-4 py-8">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-bold text-foreground">Locations</h1>
-          <div className="flex gap-2">
-            <Button variant="default" size="sm" onClick={openAddDialog}>
-              + Add Location
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => openPrintLabel(locations.map((l) => l.id))}
-              disabled={locations.length === 0}
-            >
-              🖨️ Print All Labels
-            </Button>
-          </div>
-        </div>
+        <PageHeader
+          title="Locations"
+          description="Manage storage locations and hierarchy."
+          actions={
+            <div className="flex gap-2">
+              <Button variant="default" size="sm" onClick={openAddDialog}>
+                + Add Location
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => openPrintLabel(locations.map((l) => l.id))}
+                disabled={locations.length === 0}
+              >
+                🖨️ Print All Labels
+              </Button>
+            </div>
+          }
+        />
 
         {locations.length === 0 ? (
           <div className="text-center text-muted-foreground py-12">

--- a/src/app/lots/page.tsx
+++ b/src/app/lots/page.tsx
@@ -3,6 +3,7 @@ import prisma from '@/lib/db';
 import { safeParseJson } from '@/lib/utils';
 import { LotCard, type LotCardLot } from '@/features/lots/components/LotCard';
 import { LotFilterForm } from '@/features/lots/components/LotFilterForm';
+import { PageHeader } from '@/components/PageHeader';
 
 interface PageProps {
   searchParams: Promise<{
@@ -113,12 +114,10 @@ export default async function LotsPage({ searchParams }: PageProps) {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-foreground">Lots</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {total} lot{total !== 1 ? 's' : ''} found
-          </p>
-        </div>
+        <PageHeader
+          title="Lots"
+          description={`${total} lot${total !== 1 ? 's' : ''} found`}
+        />
 
         <div className="flex gap-8">
           <Suspense fallback={null}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,231 @@
-import Link from 'next/link'
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { PageHeader } from '@/components/PageHeader';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { ProjectCard } from '@/features/projects/components/ProjectCard';
+import { safeParseJson } from '@/lib/utils';
+import type { ProjectListItem } from '@/features/projects/types';
+import type { LotListItem } from '@/features/lots/types';
+
+// --- Pinned projects ---
+const PINNED_KEY = 'pinned-projects';
+
+function loadPinnedIds(): string[] {
+  const raw = localStorage.getItem(PINNED_KEY);
+  if (!raw) return [];
+  const parsed = safeParseJson<unknown>(raw, []);
+  return Array.isArray(parsed) ? (parsed as string[]) : [];
+}
+
+// --- Low stock ---
+const DEFAULT_THRESHOLD = 5;
+const THRESHOLDS_KEY = 'stock-thresholds';
+
+interface PartStockSummary {
+  partId: string;
+  partName: string;
+  totalQuantity: number;
+}
+
+function loadThresholds(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(THRESHOLDS_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, number>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveThresholds(thresholds: Record<string, number>): void {
+  localStorage.setItem(THRESHOLDS_KEY, JSON.stringify(thresholds));
+}
 
 export default function Home() {
+  // Pinned projects state
+  const [projects, setProjects] = useState<ProjectListItem[]>([]);
+  const [pinnedIds, setPinnedIds] = useState<string[]>([]);
+
+  // Low stock state
+  const [lowStockParts, setLowStockParts] = useState<PartStockSummary[]>([]);
+  const [thresholds, setThresholds] = useState<Record<string, number>>({});
+  const [thresholdInputs, setThresholdInputs] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setPinnedIds(loadPinnedIds());
+    setThresholds(loadThresholds());
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch('/api/projects?status=active&limit=20', {
+          signal: controller.signal,
+        });
+        if (!res.ok) return;
+        const data: { data?: ProjectListItem[] } = await res.json();
+        setProjects(data.data ?? []);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
+      }
+    })();
+
+    async function fetchLowStock() {
+      try {
+        const [lowResult, outResult] = await Promise.allSettled([
+          fetch('/api/lots?status=low&limit=100'),
+          fetch('/api/lots?status=out&limit=100'),
+        ]);
+
+        const [lowData, outData] = await Promise.all([
+          lowResult.status === 'fulfilled' && lowResult.value.ok
+            ? (lowResult.value.json() as Promise<{ data: LotListItem[] }>)
+            : Promise.resolve({ data: [] as LotListItem[] }),
+          outResult.status === 'fulfilled' && outResult.value.ok
+            ? (outResult.value.json() as Promise<{ data: LotListItem[] }>)
+            : Promise.resolve({ data: [] as LotListItem[] }),
+        ]);
+
+        const allLots: LotListItem[] = [...lowData.data, ...outData.data];
+
+        const partMap = new Map<string, PartStockSummary>();
+        for (const lot of allLots) {
+          const existing = partMap.get(lot.partId);
+          const qty = lot.quantity ?? 0;
+          if (existing) {
+            existing.totalQuantity += qty;
+          } else {
+            partMap.set(lot.partId, {
+              partId: lot.partId,
+              partName: lot.part.name,
+              totalQuantity: qty,
+            });
+          }
+        }
+
+        setLowStockParts(Array.from(partMap.values()));
+      } catch {
+        // silently ignore fetch errors on dashboard
+      }
+    }
+
+    fetchLowStock();
+
+    return () => controller.abort();
+  }, []);
+
+  function handlePin(id: string) {
+    setPinnedIds((prev) => {
+      const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
+      try {
+        localStorage.setItem(PINNED_KEY, JSON.stringify(next));
+      } catch {
+        // quota exceeded or storage disabled — pinned state updated in memory only
+      }
+      return next;
+    });
+  }
+
+  function handleThresholdBlur(partId: string) {
+    const raw = thresholdInputs[partId];
+    if (raw === undefined) return;
+    const parsed = parseInt(raw, 10);
+    const value = Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_THRESHOLD;
+    setThresholds((prev) => {
+      const updated = { ...prev, [partId]: value };
+      saveThresholds(updated);
+      return updated;
+    });
+    setThresholdInputs((prev) => {
+      const next = { ...prev };
+      delete next[partId];
+      return next;
+    });
+  }
+
+  function getThreshold(partId: string): number {
+    return thresholds[partId] ?? DEFAULT_THRESHOLD;
+  }
+
+  function getThresholdDisplayValue(partId: string): string {
+    return thresholdInputs[partId] ?? String(getThreshold(partId));
+  }
+
+  const pinnedProjects = projects.filter((p) => pinnedIds.includes(p.id));
+  const unpinnedProjects = projects.filter((p) => !pinnedIds.includes(p.id));
+
   return (
-    <main className="min-h-screen bg-background">
+    <main className="min-h-screen bg-gray-50">
       <div className="mx-auto max-w-5xl px-4 py-10">
-        <h1 className="text-3xl font-bold text-foreground">Welcome to Hobby Inventory</h1>
-        <p className="mt-2 text-muted-foreground">
-          Track parts, lots, and locations for all your hobby projects.
-        </p>
+        <PageHeader
+          title="Welcome to Hobby Inventory"
+          description="Track parts, lots, and locations for all your hobby projects."
+        />
+
+        {lowStockParts.length > 0 && (
+          <section className="mt-8">
+            <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-800">
+              ⚠️ Low Stock Warnings
+            </h2>
+            <div className="flex flex-col gap-3">
+              {lowStockParts.map((part) => (
+                <Alert key={part.partId} variant="default" className="border-yellow-300 bg-yellow-50">
+                  <AlertTitle className="text-yellow-800">{part.partName}</AlertTitle>
+                  <AlertDescription>
+                    <div className="flex flex-wrap items-center gap-4 text-yellow-700">
+                      <span>Qty: {part.totalQuantity}</span>
+                      <span className="flex items-center gap-1">
+                        Threshold:
+                        <input
+                          type="number"
+                          min={0}
+                          value={getThresholdDisplayValue(part.partId)}
+                          onChange={(e) =>
+                            setThresholdInputs((prev) => ({ ...prev, [part.partId]: e.target.value }))
+                          }
+                          onBlur={() => handleThresholdBlur(part.partId)}
+                          className="ml-1 w-16 rounded border border-yellow-300 bg-white px-1 py-0.5 text-sm text-gray-800 focus:outline-none focus:ring-1 focus:ring-yellow-400"
+                          aria-label={`Stock threshold for ${part.partName}`}
+                        />
+                      </span>
+                      <Link
+                        href={`/parts/${part.partId}`}
+                        className="font-medium text-blue-600 underline hover:text-blue-800"
+                      >
+                        View Part
+                      </Link>
+                    </div>
+                  </AlertDescription>
+                </Alert>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {pinnedProjects.length > 0 && (
+          <section className="mt-8">
+            <h2 className="mb-3 text-lg font-semibold text-gray-800">📌 Pinned Projects</h2>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {pinnedProjects.map((project) => (
+                <ProjectCard
+                  key={project.id}
+                  project={project}
+                  isPinned
+                  onPin={handlePin}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           <Link
             href="/intake"
-            className="group flex flex-col gap-2 rounded-xl border border-primary/20 bg-primary/10 p-5 shadow-sm transition hover:shadow-md"
+            className="group flex flex-col gap-2 rounded-xl border border-blue-200 bg-blue-50 p-5 shadow-sm transition hover:shadow-md"
           >
             <span className="text-2xl">＋</span>
-            <h2 className="text-base font-semibold text-primary">Add to Inventory</h2>
-            <p className="text-sm text-primary/80">
+            <h2 className="text-base font-semibold text-blue-800">Add to Inventory</h2>
+            <p className="text-sm text-blue-600">
               Quick-add new parts and lots in under 60 seconds.
             </p>
           </Link>
@@ -26,8 +235,8 @@ export default function Home() {
             className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 shadow-sm transition hover:shadow-md"
           >
             <span className="text-2xl">📦</span>
-            <h2 className="text-base font-semibold text-foreground">Browse Parts</h2>
-            <p className="text-sm text-muted-foreground">Search and filter your parts catalog.</p>
+            <h2 className="text-base font-semibold text-gray-800">Browse Parts</h2>
+            <p className="text-sm text-gray-500">Search and filter your parts catalog.</p>
           </Link>
 
           <Link
@@ -35,17 +244,17 @@ export default function Home() {
             className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 shadow-sm transition hover:shadow-md"
           >
             <span className="text-2xl">🗂️</span>
-            <h2 className="text-base font-semibold text-foreground">Lots</h2>
-            <p className="text-sm text-muted-foreground">View stock quantities, sources, and locations.</p>
+            <h2 className="text-base font-semibold text-gray-800">Lots</h2>
+            <p className="text-sm text-gray-500">View stock quantities, sources, and locations.</p>
           </Link>
 
           <Link
             href="/locations"
             className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 shadow-sm transition hover:shadow-md"
           >
-            <span className="text-2xl">📍</span>
-            <h2 className="text-base font-semibold text-foreground">Locations</h2>
-            <p className="text-sm text-muted-foreground">Manage storage locations and hierarchy.</p>
+            <span className="text-2xl">��</span>
+            <h2 className="text-base font-semibold text-gray-800">Locations</h2>
+            <p className="text-sm text-gray-500">Manage storage locations and hierarchy.</p>
           </Link>
 
           <Link
@@ -53,11 +262,27 @@ export default function Home() {
             className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-5 shadow-sm transition hover:shadow-md"
           >
             <span className="text-2xl">🔧</span>
-            <h2 className="text-base font-semibold text-foreground">Projects</h2>
-            <p className="text-sm text-muted-foreground">Track part allocations across builds.</p>
+            <h2 className="text-base font-semibold text-gray-800">Projects</h2>
+            <p className="text-sm text-gray-500">Track part allocations across builds.</p>
           </Link>
         </div>
+
+        {unpinnedProjects.length > 0 && (
+          <section className="mt-8">
+            <h2 className="mb-3 text-lg font-semibold text-gray-800">Active Projects</h2>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {unpinnedProjects.map((project) => (
+                <ProjectCard
+                  key={project.id}
+                  project={project}
+                  isPinned={false}
+                  onPin={handlePin}
+                />
+              ))}
+            </div>
+          </section>
+        )}
       </div>
     </main>
-  )
+  );
 }

--- a/src/app/parts/page.tsx
+++ b/src/app/parts/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { PartsListClient } from '@/features/parts/components/PartsListClient';
+import { PageHeader } from '@/components/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Parts — Hobby Inventory',
@@ -10,12 +11,10 @@ export default function PartsPage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-foreground">Parts</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Browse and manage your parts catalog
-          </p>
-        </div>
+        <PageHeader
+          title="Parts"
+          description="Browse and manage your parts catalog"
+        />
         <PartsListClient />
       </div>
     </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ProjectsListClient } from '@/features/projects/components/ProjectsListClient';
+import { PageHeader } from '@/components/PageHeader';
 
 export const metadata: Metadata = {
   title: 'Projects — Hobby Inventory',
@@ -8,13 +9,11 @@ export const metadata: Metadata = {
 
 export default function ProjectsPage() {
   return (
-    <div className="mx-auto max-w-7xl px-4 py-8">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-foreground">Projects</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Track where your parts are going and the status of each project.
-        </p>
-      </div>
+    <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6">
+      <PageHeader
+        title="Projects"
+        description="Track where your parts are going and the status of each project."
+      />
       <ProjectsListClient />
     </div>
   );

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface PageHeaderProps {
+  title: string;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+export function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="mb-6 flex items-start justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+        {description && (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && <div className="shrink-0">{actions}</div>}
+    </div>
+  );
+}

--- a/src/features/parts/components/PartDetailClient.tsx
+++ b/src/features/parts/components/PartDetailClient.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { formatDate } from '@/lib/utils';
+import { PageHeader } from '@/components/PageHeader';
 import type { PartDetail, LotWithDetails } from '../types';
 
 function QuantityDisplay({ lot }: { lot: LotWithDetails }) {
@@ -107,24 +108,19 @@ export function PartDetailClient() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <div className="flex flex-wrap items-center gap-3">
-            <h1 className="text-2xl font-bold text-foreground">{part.name}</h1>
+      <PageHeader
+        title={part.name}
+        description={[part.category, part.manufacturer, part.mpn ? `MPN: ${part.mpn}` : null].filter(Boolean).join(' · ') || undefined}
+        actions={
+          <div className="flex items-center gap-4">
             {part.archivedAt && <Badge variant="secondary">Archived</Badge>}
+            <div className="text-right">
+              <div className="text-3xl font-bold text-foreground">{totalQuantity}</div>
+              <div className="text-sm text-muted-foreground">in stock</div>
+            </div>
           </div>
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground">
-            {part.category && <span>{part.category}</span>}
-            {part.manufacturer && <span>· {part.manufacturer}</span>}
-            {part.mpn && <span>· MPN: {part.mpn}</span>}
-          </div>
-        </div>
-        <div className="shrink-0 text-right">
-          <div className="text-3xl font-bold text-foreground">{totalQuantity}</div>
-          <div className="text-sm text-muted-foreground">in stock</div>
-        </div>
-      </div>
+        }
+      />
 
       {/* Tags */}
       {part.tags.length > 0 && (

--- a/src/features/projects/components/ProjectCard.tsx
+++ b/src/features/projects/components/ProjectCard.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
@@ -24,9 +25,11 @@ const STATUS_VARIANTS: Record<
 
 interface ProjectCardProps {
   project: ProjectListItem;
+  isPinned?: boolean;
+  onPin?: (id: string) => void;
 }
 
-export function ProjectCard({ project }: ProjectCardProps) {
+export function ProjectCard({ project, isPinned = false, onPin }: ProjectCardProps) {
   const isArchived = !!project.archivedAt;
   const reservedCount = project.allocationsByStatus.reserved ?? 0;
   const inUseCount = project.allocationsByStatus.in_use ?? 0;
@@ -36,10 +39,27 @@ export function ProjectCard({ project }: ProjectCardProps) {
     <Link
       href={`/projects/${project.id}`}
       className={cn(
-        'block rounded-lg border bg-card p-4 shadow-sm transition-shadow hover:shadow-md',
+        'relative block rounded-lg border bg-card p-4 shadow-sm transition-shadow hover:shadow-md',
         isArchived && 'opacity-60'
       )}
     >
+      {onPin && (
+        <button
+          type="button"
+          onClick={(e: React.MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onPin(project.id);
+          }}
+          aria-label={isPinned ? 'Unpin project' : 'Pin project'}
+          className={cn(
+            'absolute right-2 top-2 rounded p-0.5 text-base leading-none transition-opacity',
+            isPinned ? 'opacity-100' : 'opacity-30 hover:opacity-100'
+          )}
+        >
+          📌
+        </button>
+      )}
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <h3 className="truncate font-semibold text-foreground">{project.name}</h3>
@@ -47,7 +67,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">{project.notes}</p>
           )}
         </div>
-        <div className="flex shrink-0 flex-col items-end gap-1">
+        <div className={cn("flex shrink-0 flex-col items-end gap-1", onPin && "mr-6")}>
           {isArchived && <Badge variant="secondary">Archived</Badge>}
           <Badge variant={STATUS_VARIANTS[project.status] ?? 'default'}>
             {STATUS_LABELS[project.status] ?? project.status}

--- a/src/features/projects/components/ProjectDetailClient.tsx
+++ b/src/features/projects/components/ProjectDetailClient.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Badge } from '@/components/ui/badge';
 import { formatDate, formatDateTime } from '@/lib/utils';
+import { PageHeader } from '@/components/PageHeader';
 import type { ProjectDetail, AllocationWithDetails, ProjectEvent } from '../types';
 
 const STATUS_LABELS: Record<string, string> = {
@@ -209,33 +210,27 @@ export function ProjectDetailClient({ id }: ProjectDetailClientProps) {
 
   return (
     <div>
-      {/* Header */}
-      <div className="mb-6 flex items-start justify-between gap-4">
-        <div>
-          <div className="mb-1 flex items-center gap-3">
-            <h1 className="text-2xl font-bold text-foreground">{project.name}</h1>
+      <PageHeader
+        title={project.name}
+        actions={
+          <div className="flex flex-wrap items-center gap-3">
             <Badge variant={STATUS_VARIANTS[project.status] ?? 'default'}>
               {STATUS_LABELS[project.status] ?? project.status}
             </Badge>
-            {project.archivedAt && (
-              <Badge variant="secondary">Archived</Badge>
-            )}
+            {project.archivedAt && <Badge variant="secondary">Archived</Badge>}
+            <Link href="/projects" className="text-sm text-muted-foreground hover:underline">
+              ← Back to projects
+            </Link>
           </div>
-          {project.tags.length > 0 && (
-            <div className="flex flex-wrap gap-1 mt-2">
-              {project.tags.map((tag) => (
-                <Badge key={tag} variant="secondary">{tag}</Badge>
-              ))}
-            </div>
-          )}
+        }
+      />
+      {project.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-6">
+          {project.tags.map((tag) => (
+            <Badge key={tag} variant="secondary">{tag}</Badge>
+          ))}
         </div>
-        <Link
-          href="/projects"
-          className="shrink-0 text-sm text-blue-600 hover:underline"
-        >
-          ← Back to projects
-        </Link>
-      </div>
+      )}
 
       {/* Notes */}
       {project.notes && (

--- a/src/features/projects/components/__tests__/ProjectCard.test.tsx
+++ b/src/features/projects/components/__tests__/ProjectCard.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ProjectCard } from '../ProjectCard';
 import type { ProjectListItem } from '../../types';
 
@@ -154,5 +154,74 @@ describe('ProjectCard', () => {
     const { container } = render(<ProjectCard project={baseProject} />);
     const link = container.firstChild as HTMLElement;
     expect(link.className).not.toContain('opacity-60');
+  });
+
+  // --- Pin functionality ---
+
+  it('does not render a pin button when onPin is not provided', () => {
+    render(<ProjectCard project={baseProject} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a pin button when onPin is provided', () => {
+    render(<ProjectCard project={baseProject} onPin={jest.fn()} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('pin button has aria-label "Pin project" when not pinned', () => {
+    render(<ProjectCard project={baseProject} isPinned={false} onPin={jest.fn()} />);
+    expect(screen.getByRole('button', { name: 'Pin project' })).toBeInTheDocument();
+  });
+
+  it('pin button has aria-label "Unpin project" when pinned', () => {
+    render(<ProjectCard project={baseProject} isPinned={true} onPin={jest.fn()} />);
+    expect(screen.getByRole('button', { name: 'Unpin project' })).toBeInTheDocument();
+  });
+
+  it('calls onPin with project id when pin button is clicked', () => {
+    const onPin = jest.fn();
+    render(<ProjectCard project={baseProject} onPin={onPin} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onPin).toHaveBeenCalledTimes(1);
+    expect(onPin).toHaveBeenCalledWith('proj-1');
+  });
+
+  it('clicking pin button does not follow the card link (stopPropagation)', () => {
+    const onPin = jest.fn();
+    render(<ProjectCard project={baseProject} onPin={onPin} />);
+    const button = screen.getByRole('button');
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefaultSpy = jest.spyOn(clickEvent, 'preventDefault');
+    button.dispatchEvent(clickEvent);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('defaults isPinned to false (pin button shows Pin project label)', () => {
+    render(<ProjectCard project={baseProject} onPin={jest.fn()} />);
+    expect(screen.getByRole('button', { name: 'Pin project' })).toBeInTheDocument();
+  });
+
+  it('pin button has low opacity class when not pinned', () => {
+    render(<ProjectCard project={baseProject} isPinned={false} onPin={jest.fn()} />);
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('opacity-30');
+  });
+
+  it('pin button has full opacity class when pinned', () => {
+    render(<ProjectCard project={baseProject} isPinned={true} onPin={jest.fn()} />);
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('opacity-100');
+    expect(button.className).not.toContain('opacity-30');
+  });
+
+  it('adds right margin to status column when onPin is provided', () => {
+    const { container } = render(<ProjectCard project={baseProject} onPin={jest.fn()} />);
+    const mrDiv = container.querySelector('.mr-6');
+    expect(mrDiv).not.toBeNull();
+  });
+
+  it('does not add right margin to status column when onPin is not provided', () => {
+    const { container } = render(<ProjectCard project={baseProject} />);
+    expect(container.querySelector('.mr-6')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Integrates all three features from epic #135 (UI congruence) on top of the current main branch:

### feat(#149): Shared PageHeader component (#159) [already merged to epic branch]
- Adds src/components/PageHeader.tsx (title, description, actions props) with dark-mode-compatible text-foreground/text-muted-foreground classes
- Applies PageHeader across all list pages: parts, lots, projects, locations, intake, import
- Applies PageHeader to detail pages: PartDetailClient, ProjectDetailClient, locations/[id]/page (with path in description, back button in actions)
- Locations list page: Add Location + Print All Labels buttons in actions slot

### feat(#150): Dashboard pinned projects (#164)
- Dashboard converted to client component
- Fetches active projects on mount; lets users pin favourites via localStorage
- 📌 Pinned Projects section renders above quick-links (hidden when empty)
- Active Projects section renders below quick-links
- Pin button on each ProjectCard (isPinned/onPin props)

### feat(#151): Dashboard low stock warnings (#177)
- Fetches lots with status=low and status=out in parallel on mount
- Groups by partId, sums quantities
- ⚠️ Low Stock Warnings section with per-part configurable thresholds (persisted to localStorage key stock-thresholds, default 5)
- Section renders only when at least one low/out-stock part exists

### Integration
- Unified src/app/page.tsx combining both dashboard features
- page.test.tsx updated: mockFetch handles /api/projects endpoint, fetch call count assertions updated to 3
- All 630 tests pass

Closes #149
Closes #150
Closes #151