### PR TITLE
fix: resolve 4 test regressions from epic12 merge

### DIFF
--- a/src/components/__tests__/AppShell.test.tsx
+++ b/src/components/__tests__/AppShell.test.tsx
@@ -7,8 +7,10 @@ import { AppShell } from '../AppShell';
 
 // Mock next/navigation
 const mockPathname = jest.fn(() => '/');
+const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 // Mock next/link

--- a/src/components/__tests__/CommandPalette.test.tsx
+++ b/src/components/__tests__/CommandPalette.test.tsx
@@ -133,14 +133,18 @@ function mockFetch() {
     if (url.includes('/api/locations')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(LOCATIONS_RESPONSE) });
     }
-    return Promise.resolve({ ok: false, json: () => Promise.resolve({ data: [] }) });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
   });
 }
 
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
-  global.fetch = jest.fn();
+  // Default: return empty data so location fetch on mount doesn't throw
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ data: [] }),
+  });
 });
 
 afterEach(() => {
@@ -172,8 +176,9 @@ describe('CommandPalette', () => {
 
     fireEvent.change(screen.getByTestId('command-input'), { target: { value: 'esp' } });
 
-    // Not called immediately
-    expect(global.fetch).not.toHaveBeenCalled();
+    // Locations fetch fires on mount; parts/lots should not be called yet
+    expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining('/api/parts'));
+    expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining('/api/lots'));
 
     // After debounce
     await act(async () => {
@@ -199,7 +204,7 @@ describe('CommandPalette', () => {
       expect(screen.getByTestId('command-group-lots')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('ESP32')).toBeInTheDocument();
+    expect(screen.getAllByText('ESP32').length).toBeGreaterThan(0);
   });
 
   it('navigates to part detail page on selection', async () => {
@@ -267,7 +272,3 @@ describe('CommandPalette', () => {
     });
   });
 });
-
-
-
-

--- a/src/lib/state-transitions.ts
+++ b/src/lib/state-transitions.ts
@@ -16,7 +16,7 @@ import type {
 // ============================================================================
 
 const STOCK_TRANSITIONS: Record<StockStatus, StockStatus[]> = {
-  in_stock: ['low', 'reserved', 'installed', 'lost', 'scrapped'],
+  in_stock: ['low', 'out', 'reserved', 'installed', 'lost', 'scrapped'],
   low: ['in_stock', 'out', 'reserved', 'installed', 'lost', 'scrapped'],
   out: ['in_stock', 'low', 'scrapped'],
   reserved: ['in_stock', 'installed', 'lost', 'scrapped'],
@@ -217,4 +217,3 @@ export function deriveStatusFromQuantity(
   }
   return null;
 }
-


### PR DESCRIPTION
## Summary

Three test regressions were introduced by the epic12 merge because implementation changes were missing from main. All four failing test suites are fixed.

## Root Causes

### 1. `state-transitions.ts` — `in_stock → out` transition missing
- **Test**: `deriveStatusFromQuantity('in_stock', 0, 'exact')` expected `'out'` → got `null`
- **Fix**: Added `'out'` to `in_stock`'s valid transitions
- **Cascade fix**: `adjust/__tests__/route.test.ts` — test expected 3 tx ops (lot update + edited event + status_changed event) when qty hits 0; the status_changed event was only added when `derivedStatus !== null`, which was never true for `in_stock → out`

### 2. `AppShell.test.tsx` — `useRouter` not mocked
- `AppShell` renders `<CommandPalette>`, which calls `useRouter()`
- `next/navigation` mock only had `usePathname` — added `useRouter`

### 3. `CommandPalette.test.tsx` — `global.fetch = jest.fn()` returns `undefined`
- CommandPalette fetches `/api/locations` on mount; `jest.fn()` returns `undefined`, causing unhandled rejection
- Added default `ok: true, json: () => { data: [] }` mock in `beforeEach`
- Updated debounce assertion to tolerate the initial locations prefetch
- Changed `getByText('ESP32')` → `getAllByText('ESP32').length > 0` (ESP32 appears in both parts and lots groups)

## Files Changed
- `src/lib/state-transitions.ts` — add `'out'` to `in_stock` transitions
- `src/components/__tests__/AppShell.test.tsx` — add `useRouter` to nav mock
- `src/components/__tests__/CommandPalette.test.tsx` — fix default fetch mock, update assertions