### PR TITLE
fix(#236): add testing/failed→needs-work transition; ui-test-agent scope fallback

### DIFF
--- a/.github/workflows/orchestrator.md
+++ b/.github/workflows/orchestrator.md
@@ -267,6 +267,7 @@ When an agent reports completion, automatically dispatch the next agent:
 |---------------|-------------------|-----------|-------------|
 | `coding` | `completed` + PR created | `testing` | Dispatch test-agent |
 | `testing` | `completed` + tests added | `building` | Dispatch build-agent |
+| `testing` | `failed` | `needs-work` | Dispatch coding-agent to fix (include test failure context) |
 | `building` | `completed` + build passed | `review` | Assign Copilot reviewer |
 | `building` | `failed` | `needs-work` | Dispatch coding-agent to fix |
 | `review` | Copilot approved | `ready-to-merge` | **STOP** - Do NOT merge, wait for epic |

--- a/.github/workflows/ui-test-agent.md
+++ b/.github/workflows/ui-test-agent.md
@@ -176,6 +176,11 @@ Create the `e2e/` directory if it doesn't exist.
 
 Based on the **scope** input, write tests for the requested areas. If scope is `all`, write tests for every area below. Each test file goes in the `e2e/` directory.
 
+> ⚠️ **Unrecognized scope fallback**: If the `scope` value is not one of the recognized values (`all`, `navigation`, `parts`, `lots`, `projects`, `locations`, `intake`, `import`), treat it as `all` and include the following in your AGENT_REPORT:
+> ```json
+> "scope_warning": "unrecognized scope '<scope_value>', defaulting to all"
+> ```
+
 Follow these guidelines:
 
 #### General Testing Patterns


### PR DESCRIPTION
## Summary

Fixes two gaps in the agent workflow instructions discovered during simulation testing:

1. **`testing → failed → needs-work` missing** — The orchestrator's stage-transitions table had no row for what to do when a test-agent run fails. Issues would get permanently stuck in `testing` stage instead of going back to `needs-work` for remediation. Added the missing row, matching the existing `building → failed → needs-work` pattern.

2. **`ui-test-agent` scope fallback** — If a caller passes an unrecognized `scope` value (e.g., a typo like `"navigation-all"`), the agent had no guidance and would produce undefined behavior. Added a fallback: treat unrecognized values as `all` and log `"unrecognized scope '<value>', defaulting to all"` in the AGENT_REPORT `scope_warning` field.

## Changes

- `.github/workflows/orchestrator.md` — Added `| \`testing\` | \`failed\` | \`needs-work\` | Dispatch coding-agent to fix |` row to Task 5 transitions table
- `.github/workflows/ui-test-agent.md` — Added unrecognized scope fallback callout in Step 4

> ℹ️ No lock file changes needed — both modifications are in the markdown body (not frontmatter), so `frontmatter_hash` is unchanged.

## Testing

- [x] Stage transitions table now covers all `testing` outcomes
- [x] `ui-test-agent` scope fallback is clearly documented with example AGENT_REPORT field

Closes #236